### PR TITLE
Deprecated our kafka admin client for kafka's admin client

### DIFF
--- a/common-kafka-admin/README.md
+++ b/common-kafka-admin/README.md
@@ -7,6 +7,8 @@ operations.
 
 ### [KafkaAdminClient](src/main/java/com/cerner/common/kafka/admin/KafkaAdminClient.java)
 
+Deprecated in favor of Kafka's new [AdminClient](https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/clients/admin/AdminClient.java).
+
 * Wraps Kafka resource administration functionality including the following capabilities:
   * Topic creation and deletion
   * Topic and partition inventory

--- a/common-kafka-admin/src/main/java/com/cerner/common/kafka/admin/KafkaAdminClient.java
+++ b/common-kafka-admin/src/main/java/com/cerner/common/kafka/admin/KafkaAdminClient.java
@@ -52,6 +52,7 @@ import java.util.stream.Collectors;
  * </p>
  *
  * @author Bryan Baugher
+ * @deprecated Use Kafka's new AdminClient
  */
 public class KafkaAdminClient implements Closeable {
 

--- a/common-kafka-admin/src/main/java/com/cerner/common/kafka/admin/KafkaAdminClient.java
+++ b/common-kafka-admin/src/main/java/com/cerner/common/kafka/admin/KafkaAdminClient.java
@@ -54,6 +54,7 @@ import java.util.stream.Collectors;
  * @author Bryan Baugher
  * @deprecated Use Kafka's new AdminClient
  */
+@Deprecated
 public class KafkaAdminClient implements Closeable {
 
     /**


### PR DESCRIPTION
I looked over [Kafka's new admin client](https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/clients/admin/AdminClient.java) and it supports everything ours does so deprecating it