### PR TITLE
Make admin client connection to zookeeper lazy

### DIFF
--- a/common-kafka-admin/src/test/resources/log4j.properties
+++ b/common-kafka-admin/src/test/resources/log4j.properties
@@ -10,6 +10,7 @@ log4j.logger.kafka=WARN
 log4j.logger.org.apache.kafka=WARN
 log4j.logger.org.apache.kafka.clients.consumer.ConsumerConfig=ERROR
 log4j.logger.org.apache.kafka.clients.producer.ProducerConfig=ERROR
+log4j.logger.org.apache.kafka.clients.admin.AdminClientConfig=ERROR
 log4j.logger.org.apache.kafka.clients.NetworkClient=ERROR
 
 # Limit Zookeeper logging


### PR DESCRIPTION
The admin client may not actually always need to connect to ZK, so we should do so lazily