### PR TITLE
Increase ZK test harness connection timeout

### DIFF
--- a/common-kafka-test/src/main/java/com/cerner/common/kafka/testing/ZookeeperTestHarness.java
+++ b/common-kafka-test/src/main/java/com/cerner/common/kafka/testing/ZookeeperTestHarness.java
@@ -48,7 +48,7 @@ public class ZookeeperTestHarness {
     public ZookeeperTestHarness(int zookeeperPort) {
         this.zookeeper = null;
         this.zkUtils = null;
-        this.zkConnectionTimeout = 6000;
+        this.zkConnectionTimeout = 30000;
         this.zkSessionTimeout = 6000;
         this.zookeeperConnect = "localhost:" + zookeeperPort;
     }


### PR DESCRIPTION
This change should help avoid some spurious ZK connect failures that we have been seeing.

```
org.I0Itec.zkclient.exception.ZkTimeoutException: Unable to connect to zookeeper server within timeout: 6000
	at org.I0Itec.zkclient.ZkClient.connect(ZkClient.java:1232)
	at org.I0Itec.zkclient.ZkClient.<init>(ZkClient.java:156)
	at org.I0Itec.zkclient.ZkClient.<init>(ZkClient.java:130)
	at org.I0Itec.zkclient.ZkClient.<init>(ZkClient.java:97)
	at com.cerner.common.kafka.testing.ZookeeperTestHarness.setUp(ZookeeperTestHarness.java:82)
	at com.cerner.common.kafka.testing.KafkaBrokerTestHarness.setUp(KafkaBrokerTestHarness.java:159)
```