### PR TITLE
Update Kafka version to 2.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
   <properties>
     <hamcrest.version>1.3</hamcrest.version>
     <jackson.version>2.9.9</jackson.version>
-    <kafka.version>2.2.0</kafka.version>
+    <kafka.version>2.2.1</kafka.version>
     <scala.major.version>2.12</scala.major.version>
     <scala.version>${scala.major.version}.8</scala.version>
     <slf4j.version>1.7.25</slf4j.version>


### PR DESCRIPTION
2.2.1 was released a few days ago, so we should use that version