### PR TITLE
Update Kafka version from 2.2.1 to 2.3.1

### DIFF
--- a/common-kafka-test/src/main/java/com/cerner/common/kafka/testing/KafkaBrokerTestHarness.java
+++ b/common-kafka-test/src/main/java/com/cerner/common/kafka/testing/KafkaBrokerTestHarness.java
@@ -32,7 +32,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static scala.collection.JavaConversions.asJavaIterable;
@@ -340,36 +339,10 @@ public class KafkaBrokerTestHarness extends ZookeeperTestHarness {
     }
 
     private static KafkaServer startBroker(KafkaConfig config) {
-        KafkaServer server = new KafkaServer(config, new SystemTime(), Option.empty(),
+        KafkaServer server = new KafkaServer(config, Time.SYSTEM, Option.empty(),
                 new scala.collection.mutable.MutableList<>());
         server.startup();
         return server;
-    }
-
-    private static class SystemTime implements Time {
-        @Override
-        public long milliseconds() {
-            return System.currentTimeMillis();
-        }
-
-        @Override
-        public long nanoseconds() {
-            return System.nanoTime();
-        }
-
-        @Override
-        public void sleep(long ms) {
-            try {
-                Thread.sleep(ms);
-            } catch (InterruptedException e) {
-                // Ignore
-            }
-        }
-
-        @Override
-        public long hiResClockMs() {
-            return TimeUnit.NANOSECONDS.toMillis(milliseconds());
-        }
     }
 }
 

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
   <properties>
     <hamcrest.version>1.3</hamcrest.version>
     <jackson.version>2.9.10.1</jackson.version>
-    <kafka.version>2.2.1</kafka.version>
+    <kafka.version>2.3.1</kafka.version>
     <scala.major.version>2.12</scala.major.version>
     <scala.version>${scala.major.version}.8</scala.version>
     <slf4j.version>1.7.25</slf4j.version>


### PR DESCRIPTION
Now that Kafka 2.3.1 has been released we should upgrade common-kafka to this version.

It contains several important Kafka client bug fixes, for example:

https://issues.apache.org/jira/browse/KAFKA-7831: Consumer SubscriptionState missing synchronization

https://issues.apache.org/jira/browse/KAFKA-7961: Handle subscription changes with a rebalance in progress

https://issues.apache.org/jira/browse/KAFKA-8052: Intermittent INVALID_FETCH_SESSION_EPOCH error on FETCH request

https://issues.apache.org/jira/browse/KAFKA-8346: Improve replica fetcher behavior in handling partition failures

https://issues.apache.org/jira/browse/KAFKA-8950: KafkaConsumer stops fetching