### PR TITLE
fix

### DIFF
--- a/common-kafka/src/test/java/com/cerner/common/kafka/consumer/ProcessingPartitionTest.java
+++ b/common-kafka/src/test/java/com/cerner/common/kafka/consumer/ProcessingPartitionTest.java
@@ -2,6 +2,7 @@ package com.cerner.common.kafka.consumer;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasItem;
@@ -158,19 +159,19 @@ public class ProcessingPartitionTest {
         assertThat(partition.hasNextRecord(), is(true));
         assertRecordsAreEqual(partition.nextRecord(), record(2L));
 
-        assertThat(partition.pendingOffsets.keySet(), contains(1L, 2L));
+        assertThat(partition.pendingOffsets.keySet(), containsInAnyOrder(1L, 2L));
         assertThat(partition.offsetPosition, is(3L));
 
         assertThat(partition.hasNextRecord(), is(true));
         assertRecordsAreEqual(partition.nextRecord(), record(3L));
 
-        assertThat(partition.pendingOffsets.keySet(), contains(1L, 2L, 3L));
+        assertThat(partition.pendingOffsets.keySet(), containsInAnyOrder(1L, 2L, 3L));
         assertThat(partition.offsetPosition, is(4L));
 
         assertThat(partition.hasNextRecord(), is(false));
         assertThat(partition.nextRecord(), is(nullValue()));
 
-        assertThat(partition.pendingOffsets.keySet(), contains(1L, 2L, 3L));
+        assertThat(partition.pendingOffsets.keySet(), containsInAnyOrder(1L, 2L, 3L));
         assertThat(partition.offsetPosition, is(4L));
 
         assertThat(partition.committableOffset, is(nullValue()));
@@ -220,7 +221,7 @@ public class ProcessingPartitionTest {
 
         // Read second record
         assertRecordsAreEqual(partition.nextRecord(), record(2L));
-        assertThat(partition.pendingOffsets.keySet(), contains(1L, 2L));
+        assertThat(partition.pendingOffsets.keySet(), containsInAnyOrder(1L, 2L));
         assertThat(partition.offsetPosition, is(3L));
 
         // Fail record first record
@@ -258,13 +259,13 @@ public class ProcessingPartitionTest {
 
         assertThat(partition.hasNextRecord(), is(false));
         assertThat(partition.offsetPosition, is(3L));
-        assertThat(partition.pendingOffsets.keySet(), contains(0L, 1L, 2L));
+        assertThat(partition.pendingOffsets.keySet(), containsInAnyOrder(0L, 1L, 2L));
         assertThat(partition.completedOffsets, empty());
 
         // Ack an early record
         assertThat(partition.ack(0L), is(true));
 
-        assertThat(partition.pendingOffsets.keySet(), contains(1L, 2L));
+        assertThat(partition.pendingOffsets.keySet(), containsInAnyOrder(1L, 2L));
         assertThat(partition.completedOffsets, contains(0L));
 
         assertThat(partition.committableOffset, is(1L));
@@ -292,7 +293,7 @@ public class ProcessingPartitionTest {
 
         assertThat(partition.hasNextRecord(), is(false));
         assertThat(partition.offsetPosition, is(3L));
-        assertThat(partition.pendingOffsets.keySet(), contains(1L, 2L));
+        assertThat(partition.pendingOffsets.keySet(), containsInAnyOrder(1L, 2L));
         assertThat(partition.completedOffsets, contains(0L));
 
         assertThat(partition.committableOffset, is(1L));


### PR DESCRIPTION
## Fix a flaky test

Change some assertion to a more suitable one that is order-agnostic.

## Explanation

When we call iterate() over HashMap.KeySet, the order of the elements is non-deterministic. Thus, when the iterator returns the elements in a different order, the test fails even if the Code Under Test(CUT) itself is correct.

e.g. For keySet {1, 2, 3} and assertion:contains(1, 2 , 3), the test should pass. However,as for iterator, the returned array may be {1, 2 ,3} or {3 , 2 ,1} or others, but only {1, 2 ,3} can pass the test.

Before the fix, the test is **flaky** and it fails under **NonDex**
![before](https://user-images.githubusercontent.com/73588409/172048522-2c29ceb9-c558-4733-9241-2797ae01d471.png)

After the fix, it passes with NonDex
![after](https://user-images.githubusercontent.com/73588409/172048527-407fb3af-7c3d-44fa-a407-953367121bfd.png)

