### PR TITLE
Avoid producer leak with opentelemetry kafka extension

### DIFF
--- a/common-kafka/src/main/java/com/cerner/common/kafka/producer/KafkaProducerPool.java
+++ b/common-kafka/src/main/java/com/cerner/common/kafka/producer/KafkaProducerPool.java
@@ -207,13 +207,17 @@ public class KafkaProducerPool<K, V> implements Closeable {
                 } else {
                     int producerConcurrency = getProducerConcurrency(producerProperties);
 
+                    // clone the properties in case creating the Producer mutates them (like happens
+                    // when using opentelemtry-agent) which breaks the cache key
+                    Properties originalProperties = (Properties) producerProperties.clone();
+
                     // Create a new group of producers.
                     producers = new ArrayList<>(producerConcurrency);
                     for (int i = 0; i < producerConcurrency; ++i) {
                         producers.add(createProducer(producerProperties));
                     }
 
-                    pool.put(producerProperties, producers);
+                    pool.put(originalProperties, producers);
                 }
             } finally {
                 writeLock.unlock();


### PR DESCRIPTION
When playing around with opentelemetry, I noticed the automatic kafka instrumentation in the [agent](https://github.com/open-telemetry/opentelemetry-java-instrumentation) caused a kafka producer leak due to the way producers are cached by the properties.  I believe the opentelemetry agent was mutating the Properties.  I'll have to revisit again to provide more detail but just wanted to get this out here before I totally forget.