### PR TITLE
Issue #49 Fixed Flaky Test

### DIFF
--- a/common-kafka/src/main/java/com/cerner/common/kafka/consumer/ProcessingKafkaConsumer.java
+++ b/common-kafka/src/main/java/com/cerner/common/kafka/consumer/ProcessingKafkaConsumer.java
@@ -24,12 +24,13 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -165,7 +166,7 @@ public class ProcessingKafkaConsumer<K, V> implements Closeable {
     /**
      * Maintains the state of all the partitions our consumer is assigned to
      */
-    protected final Map<TopicPartition, ProcessingPartition<K, V>> partitions = new ConcurrentHashMap<>();
+    protected final Map<TopicPartition, ProcessingPartition<K, V>> partitions = Collections.synchronizedMap(new LinkedHashMap<>());
 
     /**
      * The partition to process from next

--- a/common-kafka/src/main/java/com/cerner/common/kafka/consumer/ProcessingKafkaConsumer.java
+++ b/common-kafka/src/main/java/com/cerner/common/kafka/consumer/ProcessingKafkaConsumer.java
@@ -24,13 +24,12 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -166,7 +165,7 @@ public class ProcessingKafkaConsumer<K, V> implements Closeable {
     /**
      * Maintains the state of all the partitions our consumer is assigned to
      */
-    protected final Map<TopicPartition, ProcessingPartition<K, V>> partitions = Collections.synchronizedMap(new LinkedHashMap<>());
+    protected final Map<TopicPartition, ProcessingPartition<K, V>> partitions = new ConcurrentHashMap<>();
 
     /**
      * The partition to process from next

--- a/common-kafka/src/test/java/com/cerner/common/kafka/consumer/ProcessingKafkaConsumerTest.java
+++ b/common-kafka/src/test/java/com/cerner/common/kafka/consumer/ProcessingKafkaConsumerTest.java
@@ -1170,7 +1170,7 @@ public class ProcessingKafkaConsumerTest {
         TopicPartition newPartition = new TopicPartition("new-topic", 0);
         when(consumer.committed(newPartition)).thenReturn(new OffsetAndMetadata(0L));
         processingConsumer.rebalanceListener.onPartitionsAssigned(Arrays.asList(topicPartition, newPartition));
-        assertThat(processingConsumer.partitions.keySet(), contains(newPartition, topicPartition));
+        assertThat(processingConsumer.partitions.keySet(), contains(topicPartition, newPartition));
         assertThat(ProcessingKafkaConsumer.REBALANCE_COUNTER.count(), is(rebalanceCount + 1));
     }
 

--- a/common-kafka/src/test/java/com/cerner/common/kafka/consumer/ProcessingKafkaConsumerTest.java
+++ b/common-kafka/src/test/java/com/cerner/common/kafka/consumer/ProcessingKafkaConsumerTest.java
@@ -1,6 +1,7 @@
 package com.cerner.common.kafka.consumer;
 
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.hamcrest.core.IsNull.nullValue;

--- a/common-kafka/src/test/java/com/cerner/common/kafka/consumer/ProcessingKafkaConsumerTest.java
+++ b/common-kafka/src/test/java/com/cerner/common/kafka/consumer/ProcessingKafkaConsumerTest.java
@@ -1,7 +1,6 @@
 package com.cerner.common.kafka.consumer;
 
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.*;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.hamcrest.core.IsNull.nullValue;
@@ -1170,7 +1169,7 @@ public class ProcessingKafkaConsumerTest {
         TopicPartition newPartition = new TopicPartition("new-topic", 0);
         when(consumer.committed(newPartition)).thenReturn(new OffsetAndMetadata(0L));
         processingConsumer.rebalanceListener.onPartitionsAssigned(Arrays.asList(topicPartition, newPartition));
-        assertThat(processingConsumer.partitions.keySet(), contains(topicPartition, newPartition));
+        assertThat(processingConsumer.partitions.keySet(), containsInAnyOrder(topicPartition, newPartition));
         assertThat(ProcessingKafkaConsumer.REBALANCE_COUNTER.count(), is(rebalanceCount + 1));
     }
 


### PR DESCRIPTION
Tests in rebalanceListener_onPartitionsAssigned() under ProcessingKafkaConsumerTest express non-deterministic behavior.  The contains() method checks the order of elements while using containsInAnyOrder() allows to check elements are present without the order mattering. Thus, the fix is changing the contains() to the containsInAnyOrder() method.